### PR TITLE
Add changelog fragments for merged dependency bumps (#44, #52)

### DIFF
--- a/.changelog/44.fixed.md
+++ b/.changelog/44.fixed.md
@@ -1,0 +1,1 @@
+Bump pytest-cov from 7.0.0 to 7.1.0

--- a/.changelog/52.fixed.md
+++ b/.changelog/52.fixed.md
@@ -1,0 +1,1 @@
+Bump ruff from 0.15.2 to 0.15.21

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,5 +8,7 @@ checklist for every contribution.
 
 ## Notes for agents
 
-Agent-specific guidance that does not belong in the human-facing
-`CONTRIBUTING.md` can be collected here. (None yet.)
+- When merging a Dependabot dependency-bump PR, remember to add a
+  `<PR-number>.fixed.md` changelog fragment for it (Dependabot does not create
+  one). This step is easy to miss because the bump PR itself touches no
+  `.changelog/` files. See the changelog section of `CONTRIBUTING.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,10 @@ This helper uses the same pytest configuration, so coverage is collected automat
   learn the PR number after opening the PR, rename the fragment then.
 - Valid fragment types are `added`, `changed`, `deprecated`, `removed`,
   `fixed` and `security`.
+- Dependency updates count too. When merging a Dependabot (or manual)
+  dependency bump, add a `<PR-number>.fixed.md` fragment such as
+  `Bump ruff from 0.15.2 to 0.15.21` — Dependabot does not create the fragment
+  itself, so it has to be added by hand to keep the changelog consistent.
 - Inspect pending fragments with `poetry run poe draftchangelog`.
 - When preparing a release, run `poetry run poe changelog` or use the `release` task (see below) to fold fragments into `CHANGELOG.md`.
 


### PR DESCRIPTION
## Summary

#44 (pytest-cov 7.0.0→7.1.0) and #52 (ruff 0.15.2→0.15.21) were merged without Towncrier fragments, which broke the project's established convention of listing dependency bumps in the changelog under **Fixed** (see the `Bump ruff …` entries in every prior release).

This restores consistency and documents the step so it isn't missed again.

## Changes

- `.changelog/44.fixed.md` — `Bump pytest-cov from 7.0.0 to 7.1.0`
- `.changelog/52.fixed.md` — `Bump ruff from 0.15.2 to 0.15.21`
- `CONTRIBUTING.md` — note in the changelog section that a `<PR>.fixed.md` fragment must be added by hand when merging a Dependabot bump (Dependabot doesn't create one).
- `AGENTS.md` — the same reminder in the agent notes, since the bump PR itself touches no `.changelog/` files and the step is easy to overlook.

## Verification

`towncrier build --draft` renders both entries under **Fixed** with linked `(#44)` / `(#52)` references, matching the historical format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1x9csC23NRWV7hMYA4sF6)_