### PR TITLE
Test on Python 3.13 and 3.14

### DIFF
--- a/.changelog/56.added.md
+++ b/.changelog/56.added.md
@@ -1,0 +1,1 @@
+Test and advertise support for Python 3.13 and 3.14.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,6 +39,6 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: ${{ matrix.python-version }} == '3.12'
+        if: matrix.python-version == '3.12'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Text Processing :: Markup :: Markdown",
   "Topic :: Utilities",
 ]


### PR DESCRIPTION
## Summary

`requires-python = ">=3.10,<4.0"` already advertises support for Python 3.13 and 3.14 (both released — 3.13 in Oct 2024, 3.14 in Oct 2025), but CI only exercised 3.10–3.12. This aligns the tested versions with the claimed support. The package has no runtime dependencies beyond the standard library, so newer interpreters are exactly where stdlib-behavior changes would surface.

## Changes

- `.github/workflows/tests.yml`: add `3.13` and `3.14` to the test matrix.
- `pyproject.toml`: add the `Python :: 3.13` and `:: 3.14` classifiers.
- `.github/workflows/tests.yml`: fix the Codecov upload condition. `if: ${{ matrix.python-version }} == '3.12'` expands to `3.12 == '3.12'` as a string, which GitHub Actions treats as always-truthy — so coverage was uploaded from every matrix leg. Changed to `if: matrix.python-version == '3.12'` so it uploads once.

## Verification

- Workflow YAML and `pyproject.toml` parse cleanly.
- The matrix itself is the verification: CI now runs the full suite on 3.10–3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1x9csC23NRWV7hMYA4sF6)_