### PR TITLE
Add changelog fragments for merged dependency bumps (#57, #58, #59)

### DIFF
--- a/.changelog/57.fixed.md
+++ b/.changelog/57.fixed.md
@@ -1,0 +1,1 @@
+Bump poethepoet from 0.37.0 to 0.48.0

--- a/.changelog/58.fixed.md
+++ b/.changelog/58.fixed.md
@@ -1,0 +1,1 @@
+Bump pytest from 8.4.2 to 9.1.1

--- a/.changelog/59.fixed.md
+++ b/.changelog/59.fixed.md
@@ -1,0 +1,1 @@
+Bump ruff from 0.15.21 to 0.16.0


### PR DESCRIPTION
## Summary
- Add `.changelog/57.fixed.md` for the poethepoet bump (0.37.0 → 0.48.0)
- Add `.changelog/58.fixed.md` for the pytest bump (8.4.2 → 9.1.1)
- Add `.changelog/59.fixed.md` for the ruff bump (0.15.21 → 0.16.0)

These Dependabot PRs were merged without changelog fragments (Dependabot doesn't create them), so they're added by hand per `AGENTS.md`/`CONTRIBUTING.md`.

## Test plan
- [x] No code changes; fragments only
- [x] `poetry run poe draftchangelog` picks up all three fragments